### PR TITLE
rename/getCrosslinkCommitteesAtSlot

### DIFF
--- a/Sources/BeaconChain/BeaconChain.swift
+++ b/Sources/BeaconChain/BeaconChain.swift
@@ -102,9 +102,9 @@ extension BeaconChain {
         return getEpochCommitteeCount(activeValidatorCount: nextActiveValidators.count)
     }
 
-    static func getCrosslinkCommitteesAtSlot(
+    static func crosslinkCommittees(
         state: BeaconState,
-        slot: Slot,
+        atSlot slot: Slot,
         registryChange: Bool = false
     ) -> [([ValidatorIndex], Shard)] {
         let epoch = slot.toEpoch()
@@ -196,7 +196,7 @@ extension BeaconChain {
     }
 
     static func getBeaconProposerIndex(state: BeaconState, slot: Slot) -> ValidatorIndex {
-        let firstCommittee = getCrosslinkCommitteesAtSlot(state: state, slot: slot)[0].0
+        let firstCommittee = crosslinkCommittees(state: state, atSlot: slot)[0].0
         return firstCommittee[Int(slot) % firstCommittee.count]
     }
 
@@ -216,7 +216,7 @@ extension BeaconChain {
         attestationData: AttestationData,
         bitfield: Data
     ) -> [ValidatorIndex] {
-        let crosslinkCommittees = getCrosslinkCommitteesAtSlot(state: state, slot: attestationData.slot)
+        let crosslinkCommittees = self.crosslinkCommittees(state: state, atSlot: attestationData.slot)
 
         assert(crosslinkCommittees.map({ return $0.1 }).contains(attestationData.shard))
 

--- a/Sources/BeaconChain/BeaconChain.swift
+++ b/Sources/BeaconChain/BeaconChain.swift
@@ -103,8 +103,8 @@ extension BeaconChain {
     }
 
     static func crosslinkCommittees(
-        state: BeaconState,
-        atSlot slot: Slot,
+        _ state: BeaconState,
+        at slot: Slot,
         registryChange: Bool = false
     ) -> [([ValidatorIndex], Shard)] {
         let epoch = slot.toEpoch()
@@ -196,7 +196,7 @@ extension BeaconChain {
     }
 
     static func getBeaconProposerIndex(state: BeaconState, slot: Slot) -> ValidatorIndex {
-        let firstCommittee = crosslinkCommittees(state: state, atSlot: slot)[0].0
+        let firstCommittee = crosslinkCommittees(state, at: slot)[0].0
         return firstCommittee[Int(slot) % firstCommittee.count]
     }
 
@@ -216,7 +216,7 @@ extension BeaconChain {
         attestationData: AttestationData,
         bitfield: Data
     ) -> [ValidatorIndex] {
-        let crosslinkCommittees = self.crosslinkCommittees(state: state, atSlot: attestationData.slot)
+        let crosslinkCommittees = self.crosslinkCommittees(state, at: attestationData.slot)
 
         assert(crosslinkCommittees.map({ return $0.1 }).contains(attestationData.shard))
 

--- a/Sources/BeaconChain/StateTransition.swift
+++ b/Sources/BeaconChain/StateTransition.swift
@@ -160,7 +160,7 @@ extension StateTransition {
             assert(attestation.custodyBitfield == Data(repeating: 0, count: 32))
             assert(attestation.aggregationBitfield != Data(repeating: 0, count: 32))
 
-            let crosslinkCommittee = BeaconChain.crosslinkCommittees(state: state, atSlot: attestation.data.slot).filter {
+            let crosslinkCommittee = BeaconChain.crosslinkCommittees(state, at: attestation.data.slot).filter {
                 $0.1 == attestation.data.shard
             }.first?.0
 
@@ -511,7 +511,7 @@ extension StateTransition {
     ) {
 
         for slot in previousEpoch.startSlot()..<nextEpoch.startSlot() {
-            let crosslinkCommitteesAtSlot = BeaconChain.crosslinkCommittees(state: state, atSlot: slot)
+            let crosslinkCommitteesAtSlot = BeaconChain.crosslinkCommittees(state, at: slot)
 
             for (_, (crosslinkCommittee, shard)) in crosslinkCommitteesAtSlot.enumerated() {
 
@@ -631,7 +631,7 @@ extension StateTransition {
         }
 
         for slot in previousEpoch.startSlot()..<currentEpoch.startSlot() {
-            let crosslinkCommitteesAtSlot = BeaconChain.crosslinkCommittees(state: state, atSlot: slot)
+            let crosslinkCommitteesAtSlot = BeaconChain.crosslinkCommittees(state, at: slot)
 
             for (_, (crosslinkCommittee, shard)) in crosslinkCommitteesAtSlot.enumerated() {
 

--- a/Sources/BeaconChain/StateTransition.swift
+++ b/Sources/BeaconChain/StateTransition.swift
@@ -160,7 +160,7 @@ extension StateTransition {
             assert(attestation.custodyBitfield == Data(repeating: 0, count: 32))
             assert(attestation.aggregationBitfield != Data(repeating: 0, count: 32))
 
-            let crosslinkCommittee = BeaconChain.getCrosslinkCommitteesAtSlot(state: state, slot: attestation.data.slot).filter {
+            let crosslinkCommittee = BeaconChain.crosslinkCommittees(state: state, atSlot: attestation.data.slot).filter {
                 $0.1 == attestation.data.shard
             }.first?.0
 
@@ -511,7 +511,7 @@ extension StateTransition {
     ) {
 
         for slot in previousEpoch.startSlot()..<nextEpoch.startSlot() {
-            let crosslinkCommitteesAtSlot = BeaconChain.getCrosslinkCommitteesAtSlot(state: state, slot: slot)
+            let crosslinkCommitteesAtSlot = BeaconChain.crosslinkCommittees(state: state, atSlot: slot)
 
             for (_, (crosslinkCommittee, shard)) in crosslinkCommitteesAtSlot.enumerated() {
 
@@ -631,7 +631,7 @@ extension StateTransition {
         }
 
         for slot in previousEpoch.startSlot()..<currentEpoch.startSlot() {
-            let crosslinkCommitteesAtSlot = BeaconChain.getCrosslinkCommitteesAtSlot(state: state, slot: slot)
+            let crosslinkCommitteesAtSlot = BeaconChain.crosslinkCommittees(state: state, atSlot: slot)
 
             for (_, (crosslinkCommittee, shard)) in crosslinkCommitteesAtSlot.enumerated() {
 


### PR DESCRIPTION
should `state` become an unnamed parameter?